### PR TITLE
add version setting for eslint-react-plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,5 +22,10 @@
     "jsx-a11y/anchor-is-valid": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }


### PR DESCRIPTION
otherwise it complains about this setting missing when running `npm run lint`