### PR TITLE
remove eslintConfig from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,9 +53,6 @@
     "lint": "eslint src/**/*.js",
     "lint:fix": "eslint src/**/*.js --fix"
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
as you should either use just `eslintConfig` in package.json or the `.eslintrc` file, not both, as it may confuse some tooling.