### PR TITLE
add double quotes around eslint glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "build": "react-scripts build",
     "build:deploy": "react-scripts build && scp -r ./build/* jeramey@speakeasy.tools:/var/www/speakeasy.tools/html",
     "eject": "react-scripts eject",
-    "lint": "eslint src/**/*.js",
-    "lint:fix": "eslint src/**/*.js --fix"
+    "lint": "eslint \"src/**/*.js\"",
+    "lint:fix": "eslint \"src/**/*.js\" --fix"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
as otherwise people get different results on windows vs *nix because specifying a path in eslint is garbage