### PR TITLE
Fix firebase warning about production

### DIFF
--- a/src/CloudFunctions/SpeechToText.js
+++ b/src/CloudFunctions/SpeechToText.js
@@ -1,4 +1,5 @@
-import firebase from "firebase";
+import firebase from "firebase/app";
+import "firebase/functions";
 
 const RecognizeSpeech = firebase.functions().httpsCallable("recognize");
 

--- a/src/CloudFunctions/TextToSpeech.js
+++ b/src/CloudFunctions/TextToSpeech.js
@@ -1,4 +1,6 @@
-import firebase from "firebase";
+import firebase from "firebase/app";
+import "firebase/functions";
+import "firebase/storage";
 import { translate } from "./Translate";
 
 const Synthesize = firebase.functions().httpsCallable("synthesize");

--- a/src/CloudFunctions/Translate.js
+++ b/src/CloudFunctions/Translate.js
@@ -1,4 +1,6 @@
-import firebase from "firebase";
+import firebase from "firebase/app";
+import "firebase/functions";
+
 const DetectLanguage = firebase.functions().httpsCallable("detectLanguage");
 const ListLanguages = firebase.functions().httpsCallable("listLanguages");
 const Translate = firebase.functions().httpsCallable("translate");

--- a/src/Firebase/FirebaseUI.js
+++ b/src/Firebase/FirebaseUI.js
@@ -1,5 +1,6 @@
 import React from "react";
-import firebase from "firebase";
+import firebase from "firebase/app";
+import "firebase/auth";
 import { StyledFirebaseAuth } from "react-firebaseui";
 
 const uiConfig = {


### PR DESCRIPTION
This gets rid of the following warning that was showing up in console:
> It looks like you're using the development build of the Firebase JS SDK. When deploying Firebase apps to production, it is advisable to only import the individual SDK components you intend to use.

Essentially, anytime we want to use firebase within the application, you have to do:

```javascript
import firebase from "firebase/app";
```

and then underneath additional imports for each piece of functionality of firebase you might use on that page. For example, on a page where might use auth, functions, and storage, it would be:

```javascript
import firebase from "firebase/app";
import "firebase/auth";
import "firebase/functions";
import "firebase/storage";
```