### PR TITLE
set clsx dependency to ^1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "apollo-client": "^2.6.8",
     "apollo-link-context": "^1.0.19",
     "apollo-link-http": "^1.5.16",
-    "clsx": "latest",
+    "clsx": "^1.1.1",
     "color-interpolate": "^1.0.5",
     "cors": "^2.8.5",
     "date-fns": "^2.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3698,7 +3698,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.0.2, clsx@^1.0.4, clsx@latest:
+clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==


### PR DESCRIPTION
This pins the `clsx` dependency to use `^1.1.1` version instead of `latest`. Both `latest` and `1.1.1` currently point to the same thing, and `1.1.1` is considered production ready, and so no reason not to be explicit, and avoid any unexpected BC breaks if a `2.0.0` were released.

This also will fix the warning:
> Pattern ["clsx@latest"] is trying to unpack in the same destination "/home/mpeveler/.cache/yarn/v6/npm-clsx-1.1.1-98b3134f9abbdf23b2663491ace13c5c03a73188-integrity/node_modules/clsx" as pattern ["clsx@^1.0.4","clsx@^1.0.4","clsx@^1.0.4","clsx@^1.0.2","clsx@^1.0.2"]. This could result in non-deterministic behavior, skipping.

when doing `yarn install` (experienced both on WSL and macOS).